### PR TITLE
Feature/issue 86

### DIFF
--- a/src/pages/4-combining-actions.md
+++ b/src/pages/4-combining-actions.md
@@ -79,11 +79,9 @@ Method       Arguments                       Result Type                    Note
 
 
 <div class="callout callout-warning">
-**Combined Actions do not use a common transaction**
+**Combined Actions Are Not Automatically Transactions**
 
-It is important to note that by default combined actions run in their own transactions.
-
-We'll see how to tell Slick to do this a little later in the [Transactions][Transactions] section.
+By default, when you combine actions together you do not get a single transaction.  At the [end of this chapter][Transactions] we'll see that it's very easy to run combined actions in a transaction with `db.run(actions.transactionally)`.
 </div>
 
 


### PR DESCRIPTION
- Fixed a parse error 
- Added a warning on combined actions running in their own transaction rather than a shared transaction.
