### PR TITLE
Add link to mailing list for the HTML version

### DIFF
--- a/src/templates/template.html
+++ b/src/templates/template.html
@@ -48,7 +48,7 @@ $endfor$
 <div class="hero-arrow-overlay-white"></div>
 <div class="container">
   <div class="mailing-list" style="text-align: center; font-weight: lighter">
-    To hear about new editions of this book, <a style="color: white; font-weight: normal" href="http://underscore.us16.list-manage.com/subscribe/post?u=974a09ebc30fbb878c41436ec&id=d99e5ae861">join the mailing list</a>.
+    To hear about new editions of this book, <a style="color: white; font-weight: normal" href="http://underscore.us16.list-manage.com/subscribe/post?u=974a09ebc30fbb878c41436ec&id=d99e5ae861">subscribe to the newsletter</a>.
   </div>
 <div class="hero-text">
 $if(title)$

--- a/src/templates/template.html
+++ b/src/templates/template.html
@@ -47,6 +47,9 @@ $endfor$
 <div class="hero-right-overlay-white"></div>
 <div class="hero-arrow-overlay-white"></div>
 <div class="container">
+  <div class="mailing-list" style="text-align: center; font-weight: lighter">
+    To hear about new editions of this book, <a style="color: white; font-weight: normal" href="http://underscore.us16.list-manage.com/subscribe/post?u=974a09ebc30fbb878c41436ec&id=d99e5ae861">join the mailing list</a>.
+  </div>
 <div class="hero-text">
 $if(title)$
 <h1 class="title$if(subtitle)$ with-subtitle$endif$">


### PR DESCRIPTION
The change is....

![essential slick news 2018-02-06 11-47-08](https://user-images.githubusercontent.com/102661/35858215-8e71fcc6-0b33-11e8-8db8-7c482a912713.png)

...which walks you through sign up to the _Essential Slick_ newsletter.

NB: it looks like custom css class definitions are stripped from the HTML by the build, so I had to use in-line styles here.