### PR TITLE
update to Scala 2.13.3 and fix deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Essential Slick
 
-[![Build Status](https://travis-ci.org/underscoreio/essential-slick.svg?branch=3.2)](https://travis-ci.org/underscoreio/essential-slick)
+[![Build Status](https://travis-ci.org/underscoreio/essential-slick.svg?branch=3.3)](https://travis-ci.org/underscoreio/essential-slick)
 
 [slick]: http://slick.lightbend.com
 [download]: https://underscore.io/books/essential-slick/
@@ -47,27 +47,27 @@ This book uses [Underscore's ebook build system][ebook-template].
 
 The simplest way to build the book is to use [Docker Compose](http://docker.com):
 
-- install Docker Compose (`brew install docker-compose` on OS X; or download from [docker.com](http://docker.com/)); and
+- install Docker Compose; and
 - run `go.sh` (or `docker-compose run book bash` if `go.sh` doesn't work).
 
 This will open a `bash` shell running inside the Docker container which contains all the dependencies to build the book. From the shell run:
 
 - `mkdir dist`
 - `npm install`; and then
-- `sbt`.
+- `./sbt.sh`.
 
-To avoid running out of MetaSpace you'll also want to:
+Within `sbt` you can issue the commands `pdf`, `html`, `epub`, or `all` to build the desired format(s) of the book. 
 
-```
-export JAVA_OPTS="-Xmx3g -XX:+TieredCompilation -XX:ReservedCodeCacheSize=256m -XX:+UseNUMA -XX:+UseParallelGC -XX:+CMSClassUnloadingEnabled"
-```
+When you build the book, you'll see `Unknown link` warning messages.
+You can ignore these (and if anyone wants to find out why they happen, do go for it).
 
-Within `sbt` you can issue the commands `pdf`, `html`, `epub`, or `all` to build the desired format(s) of the book. Targets are placed in the `dist` directory.
+The results are placed in the `dist` directory.
+
 
 ## Writing
 
-Essential Slick uses [mdoc] to check the Scala code on the book.
-The source files are in `src/pages`.
-The converted sources are output to `target/pages`.
+- Essential Slick uses [mdoc] to check the Scala code on the book.
+- The source files are in `src/pages`.
+- The converted sources are output to `target/pages`.
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val root = project
   .settings(
     mdocIn := sourceDirectory.value / "pages",
     mdocOut := target.value / "pages",
-    scalaVersion := "2.13.1",
+    scalaVersion := "2.13.3",
     version := "3.0.0",
     libraryDependencies ++= Seq(
       "com.typesafe.slick" %% "slick"           % "3.3.3",

--- a/src/pages/1-basics.md
+++ b/src/pages/1-basics.md
@@ -162,7 +162,7 @@ name := "essential-slick-chapter-01"
 
 version := "1.0.0"
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.3"
 
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick"           % "3.3.3",

--- a/src/pages/5-data_modelling.md
+++ b/src/pages/5-data_modelling.md
@@ -248,7 +248,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
     class UserTable3(tag: Tag) extends Table[User](tag, "user") {
       def id   = column[Long]("id", O.PrimaryKey, O.AutoInc)
       def name = column[String]("name")
-      def * = (name, id) <> (User.tupled, User.unapply)
+      def * = (name, id).<>(User.tupled, User.unapply)
     }
 ```
 
@@ -288,7 +288,7 @@ and Slick builds the resulting shape. Here our `B` is the `User` case class:
     class UserTable3(tag: Tag) extends Table[User](tag, "user") {
       def id   = column[Long]("id", O.PrimaryKey, O.AutoInc)
       def name = column[String]("name")
-      def * = (name, id) <> (User.tupled, User.unapply)
+      def * = (name, id).<>(User.tupled, User.unapply)
     }
     ```
     <!-- If you change this ^^ code update the invisible block above -->
@@ -327,7 +327,7 @@ and write:
 class UserTable(tag: Tag) extends Table[User](tag, "user") {
   def id   = column[Long]("id", O.PrimaryKey, O.AutoInc)
   def name = column[String]("name")
-  def * = (name, id) <> (intoUser, fromUser)
+  def * = (name, id).<>(intoUser, fromUser)
 }
 ```
 
@@ -1786,7 +1786,7 @@ The most important points are:
 - We can represent rows in a variety of ways: tuples, `HList`s,
   and arbitrary classes and case classes via the `mapTo` macro.
 
-- If we need more control over a mapping from columns to other data structures, the `<>` method is avaiilable.
+- If we need more control over a mapping from columns to other data structures, the `<>` method is available.
 
 - We can represent individual values in columns
   using arbitrary Scala data types
@@ -2257,7 +2257,7 @@ class LegacyUserTable(tag: Tag) extends Table[User](tag, "legacy") {
      user.address.city, user.address.country, user.id)
   )
 
-  def * = (name, email, street, city, country, id) <> (pack, unpack)
+  def * = (name, email, street, city, country, id).<>(pack, unpack)
 }
 
 lazy val legacyUsers = TableQuery[LegacyUserTable]

--- a/src/pages/7-plain_sql.md
+++ b/src/pages/7-plain_sql.md
@@ -197,11 +197,11 @@ And Slick knows how to handle `Long` and `String`.
 So that leaves us with `Option[DateTime]` and the `Message` itself.
 
 For optional values, Slick provides `nextXXXOption` methods, such as `nextLongOption`.
-For the optional date time we read the database value using `nextTimestampOption` and then `map` to the right type:
+For the optional date time we read the database value using `nextTimestampOption()` and then `map` to the right type:
 
 ```scala mdoc
 implicit val GetOptionalDateTime = GetResult[Option[DateTime]](r =>
-  r.nextTimestampOption.map(ts => new DateTime(ts, UTC))
+  r.nextTimestampOption().map(ts => new DateTime(ts, UTC))
 )
 ```
 
@@ -693,7 +693,7 @@ The steps are:
 import slick.jdbc.GetResult
 
 implicit val GetFirstAndLast =
-  GetResult[FirstAndLast](r => FirstAndLast(r.nextString, r.nextString))
+  GetResult[FirstAndLast](r => FirstAndLast(r.nextString(), r.nextString()))
 
 
 val query =  sql""" select min("content"), max("content")


### PR DESCRIPTION
The depecations fixed:

1. For `<>` and autotupling

We had a few cases of:

```
def * = (col1, col2, col3) <> (f, g)
```

This is deprecated for autotupling changes. Thankfully we don't need `<>` any more (with `mapTo`),
but where we do show it we've gone for:

```
def * = (col1, col2, col3).<>(f, g)
```

2. Empty parameter list

A small number of cases of `foo` where the method was defined as `foo()`, so now we must call it as `foo()`.